### PR TITLE
added DNS name changes for mgmt-ui and file-drop

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,8 @@ module "create_aks_cluster_UKWest" {
 	icap_tlsport              =   "${var.icap_tlsport}"
 	dns_name_01               =   "icap-${var.suffix}"
 	dns_name_04               =   "management-ui-${var.suffix}.${var.domain}"
+	a_record_01				  =   "management-ui-${var.suffix}"
+
 
 	kv_vault_name            =    "aks-kv-${var.suffix}"
 	storage_resource         =    "aks-storage-${var.suffix}"
@@ -30,7 +32,7 @@ module "create_aks_cluster_file_drop_UKWest" {
 	region                    =   "${var.azure_region}"
 	cluster_name              =   "fd-clu-${var.suffix}"
 	file_drop_dns_name_01     =   "file-drop-${var.suffix}.${var.domain}"
-
+	a_record_02				  =   "file-drop-${var.suffix}"
 }
 
 # Storage Account Modules
@@ -52,6 +54,6 @@ module "create_key_vault_UKWest" {
 	mgmt_dns                  =   "management-ui-${var.suffix}.${var.domain}"
 	file_drop_dns             =   "file-drop-${var.suffix}.${var.domain}"
 
-	enable_cutomser_cert     =   "${var.enable_cutomser_cert}"
+	enable_customer_cert     =   "${var.enable_customer_cert}"
 
 }

--- a/modules/clusters/aks01/main.tf
+++ b/modules/clusters/aks01/main.tf
@@ -19,6 +19,19 @@ resource "azurerm_resource_group" "resource_group" {
   }
 }
 
+# resource "azurerm_public_ip" "nginx-public-ip" {
+#   name                = "nginx-public-ip-1"
+#   resource_group_name = azurerm_resource_group.resource_group.name
+#   location            = azurerm_resource_group.resource_group.location
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+
+#   tags = {
+#     created_by         = "Glasswall Solutions"
+#     deployment_version = "1.0.0"
+#   }
+# }
+
 resource "azurerm_kubernetes_cluster" "icap-deploy" {
   name                = var.cluster_name
   location            = azurerm_resource_group.resource_group.location
@@ -89,6 +102,11 @@ resource "helm_release" "ingress-nginx" {
   chart            = var.chart_repo03
   wait             = true
   cleanup_on_fail  = true
+
+  set {
+        name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-dns-label-name"
+        value = var.a_record_01
+    }
 
   depends_on = [ 
     azurerm_kubernetes_cluster.icap-deploy,
@@ -185,7 +203,7 @@ resource "null_resource" "get_kube_context" {
 
  provisioner "local-exec" {
 
-    command = "/bin/bash az aks get-credentials --resource-group ${var.resource_group} --name ${var.cluster_name} --overwrite-existing"
+    command = "az aks get-credentials --resource-group ${var.resource_group} --name ${var.cluster_name} --overwrite-existing"
   }
   
   depends_on = [

--- a/modules/clusters/aks01/main.tf
+++ b/modules/clusters/aks01/main.tf
@@ -19,19 +19,6 @@ resource "azurerm_resource_group" "resource_group" {
   }
 }
 
-# resource "azurerm_public_ip" "nginx-public-ip" {
-#   name                = "nginx-public-ip-1"
-#   resource_group_name = azurerm_resource_group.resource_group.name
-#   location            = azurerm_resource_group.resource_group.location
-#   allocation_method   = "Static"
-#   sku                 = "Standard"
-
-#   tags = {
-#     created_by         = "Glasswall Solutions"
-#     deployment_version = "1.0.0"
-#   }
-# }
-
 resource "azurerm_kubernetes_cluster" "icap-deploy" {
   name                = var.cluster_name
   location            = azurerm_resource_group.resource_group.location

--- a/modules/clusters/aks01/outputs.tf
+++ b/modules/clusters/aks01/outputs.tf
@@ -39,7 +39,3 @@ output "kube_config" {
     value = azurerm_kubernetes_cluster.icap-deploy.kube_config_raw
     sensitive = true
 }
-
-# output "nginx_public_ip" {
-#     value = azurerm_public_ip.publicIp.ipAddress
-# }

--- a/modules/clusters/aks01/outputs.tf
+++ b/modules/clusters/aks01/outputs.tf
@@ -39,3 +39,7 @@ output "kube_config" {
     value = azurerm_kubernetes_cluster.icap-deploy.kube_config_raw
     sensitive = true
 }
+
+# output "nginx_public_ip" {
+#     value = azurerm_public_ip.publicIp.ipAddress
+# }

--- a/modules/clusters/aks01/variables.tf
+++ b/modules/clusters/aks01/variables.tf
@@ -132,7 +132,13 @@ variable "chart_path04" {
 variable "dns_name_04" {
   description = "DNS name for Management-UI"
   type = string
-  default = "management-ui-ukw.ukwest.cloudapp.azure.com"
+  default = "management-ui.ukwest.cloudapp.azure.com"
+}
+
+variable "a_record_01" {
+  description = "A record for Management-UI"
+  type = string
+  default = "management-ui"
 }
 
 ## Rabbitmq-Operator Chart

--- a/modules/clusters/file-drop-cluster/main.tf
+++ b/modules/clusters/file-drop-cluster/main.tf
@@ -93,6 +93,11 @@ resource "helm_release" "ingress-nginx" {
   wait             = true
   cleanup_on_fail  = true
 
+  set {
+        name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-dns-label-name"
+        value = var.a_record_02
+    }
+
   depends_on = [ 
     azurerm_kubernetes_cluster.file-drop,
    ]
@@ -102,7 +107,7 @@ resource "null_resource" "get_kube_context" {
 
  provisioner "local-exec" {
 
-    command = "/bin/bash az aks get-credentials --resource-group ${var.resource_group} --name ${var.cluster_name} --overwrite-existing"
+    command = "az aks get-credentials --resource-group ${var.resource_group} --name ${var.cluster_name} --overwrite-existing"
   }
   
   depends_on = [

--- a/modules/clusters/file-drop-cluster/variables.tf
+++ b/modules/clusters/file-drop-cluster/variables.tf
@@ -46,8 +46,15 @@ variable "chart_path01" {
 variable "file_drop_dns_name_01" {
   description = "This is the DNS name for the ingress"
   type        = string
-  default     = "file-drop-ukw.ukwest.cloudapp.azure.com"
+  default     = "file-drop.ukwest.cloudapp.azure.com"
 }
+
+variable "a_record_02" {
+  description = "A record for File-Drop"
+  type = string
+  default = "file-drop"
+}
+
 
 ## Cert-Manager Chart
 variable "release_name02" {

--- a/modules/keyvaults/keyvault-ukw/main.tf
+++ b/modules/keyvaults/keyvault-ukw/main.tf
@@ -107,7 +107,7 @@ resource "null_resource" "create_dirs" {
 
 resource "null_resource" "create_icap_certs" {
 
- count = var.enable_cutomser_cert ? 0 : 1
+ count = var.enable_customer_cert ? 0 : 1
 
  provisioner "local-exec" {
 


### PR DESCRIPTION
Added the following:

- DNS Fix for file-drop and mgmt-ui
- Updated variables to reflect this change and added to main.tf
- Removed ```/bin/bash``` from the start of the ```get credentials``` local_exec, as this was causing issues with the output. Due to this az command using python instead of bash.
- Fixed typo on customer certs flag